### PR TITLE
Add penalty cost for binding constraints

### DIFF
--- a/docs/developer-guide/CHANGELOG.md
+++ b/docs/developer-guide/CHANGELOG.md
@@ -14,6 +14,7 @@ toc_depth: 2
 * Short term storage: penalty for storage control, injection and withdrawal flow gradient [ANT-2300] (#2491)
 * Make it possible to specify the final hydro reservoir level [ANT-1084] (#1521)
 * Major changes on the hydro behavior. Use overflow from the weekly optimization problem, don't recompute levels as a post-processing. These changes improve the handling of min-gen constraints for hydro reservoirs. [ANT-1825]
+* Binding constraints: optional penalty-cost with slack variables
 
 #### Removed features
 * Remove hydro hotstart (#2131)

--- a/docs/user-guide/04-migration-guides.md
+++ b/docs/user-guide/04-migration-guides.md
@@ -386,6 +386,7 @@ They control which marginal price time granularity is printed, either regarding 
 
 * `filter-year-by-year`. Default value = hourly, daily, weekly, monthly, annual
 * `filter-synthesis`. Default value = hourly, daily, weekly, monthly, annual
+* `penalty-cost`. Optional penalty (€/MWh) applied when the constraint is relaxed
 
 #### Marginal cost for binding constraints
 

--- a/docs/user-guide/solver/02-inputs.md
+++ b/docs/user-guide/solver/02-inputs.md
@@ -794,6 +794,7 @@ The Binding Constraints section of the AntaresWeb interface for this section inv
   - Time-range (hourly, daily, weekly)
   - Numerical type (equality, bounded above, below, on both sides)
   - Status (active /enabled or inactive/disabled)
+  - Optional `penalty-cost` to soften the constraint (€/MWh)
 
 - **TAB "weights"**
   Definition of the coefficients given to each flow variable or generation variable in the formulation of the constraints. Two sub-tabs make it possible to handle the coefficients associated with transmission assets (links) and those associated with generation assets (thermal clusters). In both cases:

--- a/src/libs/antares/study/binding_constraint/BindingConstraintLoader.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraintLoader.cpp
@@ -96,6 +96,11 @@ std::vector<std::shared_ptr<BindingConstraint>> BindingConstraintLoader::load(En
             bc->group_ = p->value.c_str();
             continue;
         }
+        if (p->key == "penalty-cost")
+        {
+            bc->penaltyCost = p->value.to<double>();
+            continue;
+        }
 
         // initialize the values
         double w = .0;

--- a/src/libs/antares/study/binding_constraint/BindingConstraintSaver.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraintSaver.cpp
@@ -50,6 +50,7 @@ bool BindingConstraintSaver::saveToEnv(EnvForSaving& env,
     env.section->add("filter-synthesis",
                      datePrecisionIntoString(bindingConstraint->pFilterSynthesis));
     env.section->add("group", bindingConstraint->group());
+    env.section->add("penalty-cost", bindingConstraint->penalty());
 
     if (!bindingConstraint->pComments.empty())
     {

--- a/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraint.h
+++ b/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraint.h
@@ -177,6 +177,11 @@ public:
     std::string group() const;
     void group(std::string group_name);
 
+    //! \name Penalty cost
+    //@{
+    double penalty() const { return penaltyCost; }
+    void penalty(double value) { penaltyCost = value; }
+
     /*!
     ** \brief Set the comments
     */
@@ -407,6 +412,8 @@ private:
     YString pComments;
     //! Group
     std::string group_ = "default";
+    //! Penalty cost for soft constraint handling
+    double penaltyCost = 0.;
 
     void clear();
 

--- a/src/solver/optimisation/constraints/BindingConstraintDay.cpp
+++ b/src/solver/optimisation/constraints/BindingConstraintDay.cpp
@@ -79,6 +79,19 @@ void BindingConstraintDay::add(int cntCouplante)
           .NumeroDeContrainteDesContraintesCouplantes[cntCouplante]
           = builder.data.nombreDeContraintes;
 
+        auto* bcPtr = MatriceDesContraintesCouplantes.bindingConstraint.get();
+        if (bcPtr && bcPtr->penalty() > 0.)
+        {
+            if (MatriceDesContraintesCouplantes.SensDeLaContrainteCouplante != '>')
+            {
+                builder.BindingConstraintPenaltyPos(cntCouplante, -1.0);
+            }
+            if (MatriceDesContraintesCouplantes.SensDeLaContrainteCouplante != '<')
+            {
+                builder.BindingConstraintPenaltyNeg(cntCouplante, 1.0);
+            }
+        }
+
         builder.SetOperator(MatriceDesContraintesCouplantes.SensDeLaContrainteCouplante);
         {
             ConstraintNamer namer(builder.data.NomDesContraintes);

--- a/src/solver/optimisation/constraints/BindingConstraintHour.cpp
+++ b/src/solver/optimisation/constraints/BindingConstraintHour.cpp
@@ -68,6 +68,19 @@ void BindingConstraintHour::add(int pdt, int cntCouplante)
                                                                  builder.data.NombreDePasDeTemps);
     }
 
+    auto* bcPtr = MatriceDesContraintesCouplantes.bindingConstraint.get();
+    if (bcPtr && bcPtr->penalty() > 0.)
+    {
+        if (MatriceDesContraintesCouplantes.SensDeLaContrainteCouplante != '>')
+        {
+            builder.BindingConstraintPenaltyPos(cntCouplante, -1.0);
+        }
+        if (MatriceDesContraintesCouplantes.SensDeLaContrainteCouplante != '<')
+        {
+            builder.BindingConstraintPenaltyNeg(cntCouplante, 1.0);
+        }
+    }
+
     builder.SetOperator(MatriceDesContraintesCouplantes.SensDeLaContrainteCouplante);
     {
         ConstraintNamer namer(builder.data.NomDesContraintes);

--- a/src/solver/optimisation/constraints/BindingConstraintWeek.cpp
+++ b/src/solver/optimisation/constraints/BindingConstraintWeek.cpp
@@ -66,6 +66,19 @@ void BindingConstraintWeek::add(int cntCouplante)
         }
     }
 
+    auto* bcPtr = MatriceDesContraintesCouplantes.bindingConstraint.get();
+    if (bcPtr && bcPtr->penalty() > 0.)
+    {
+        if (MatriceDesContraintesCouplantes.SensDeLaContrainteCouplante != '>')
+        {
+            builder.BindingConstraintPenaltyPos(cntCouplante, -1.0);
+        }
+        if (MatriceDesContraintesCouplantes.SensDeLaContrainteCouplante != '<')
+        {
+            builder.BindingConstraintPenaltyNeg(cntCouplante, 1.0);
+        }
+    }
+
     builder.SetOperator(MatriceDesContraintesCouplantes.SensDeLaContrainteCouplante);
 
     data.NumeroDeContrainteDesContraintesCouplantes[cntCouplante] = builder.data

--- a/src/solver/optimisation/constraints/ConstraintBuilder.cpp
+++ b/src/solver/optimisation/constraints/ConstraintBuilder.cpp
@@ -202,6 +202,18 @@ ConstraintBuilder& ConstraintBuilder::NegativeUnsuppliedEnergy(unsigned int inde
     return *this;
 }
 
+ConstraintBuilder& ConstraintBuilder::BindingConstraintPenaltyPos(unsigned int index, double coeff)
+{
+    AddVariable(variableManager_.BindingConstraintPenaltyPos(index, hourInWeek_), coeff);
+    return *this;
+}
+
+ConstraintBuilder& ConstraintBuilder::BindingConstraintPenaltyNeg(unsigned int index, double coeff)
+{
+    AddVariable(variableManager_.BindingConstraintPenaltyNeg(index, hourInWeek_), coeff);
+    return *this;
+}
+
 ConstraintBuilder& ConstraintBuilder::LayerStorage(unsigned area, unsigned layer, double coeff)
 {
     AddVariable(variableManager_.LayerStorage(area, layer), coeff);

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/ConstraintBuilder.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/ConstraintBuilder.h
@@ -154,6 +154,9 @@ public:
 
     ConstraintBuilder& NegativeUnsuppliedEnergy(unsigned int index, double coeff);
 
+    ConstraintBuilder& BindingConstraintPenaltyPos(unsigned int index, double coeff);
+    ConstraintBuilder& BindingConstraintPenaltyNeg(unsigned int index, double coeff);
+
     ConstraintBuilder& LayerStorage(unsigned area, unsigned layer, double coeff);
 
     //@}

--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
@@ -113,6 +113,8 @@ public:
     void LayerStorage(unsigned int variable, int layerIndex);
     void PositiveUnsuppliedEnergy(unsigned int variable);
     void NegativeUnsuppliedEnergy(unsigned int variable);
+    void BindingConstraintPenaltyPos(unsigned int variable, const std::string& name);
+    void BindingConstraintPenaltyNeg(unsigned int variable, const std::string& name);
     void AreaBalance(unsigned int variable);
 
 private:

--- a/src/solver/optimisation/opt_construction_variables_optimisees_lineaire.cpp
+++ b/src/solver/optimisation/opt_construction_variables_optimisees_lineaire.cpp
@@ -145,6 +145,36 @@ void OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaire(PROBLEME_HEBD
             ProblemeAResoudre->TypeDeVariable[NombreDeVariables] = VARIABLE_BORNEE_INFERIEUREMENT;
             variableNamer.NegativeUnsuppliedEnergy(NombreDeVariables);
             NombreDeVariables++;
+
+        for (uint32_t bc = 0; bc < problemeHebdo->NombreDeContraintesCouplantes; ++bc)
+        {
+            const auto* bcPtr = problemeHebdo->MatriceDesContraintesCouplantes[bc].bindingConstraint.get();
+            if (!bcPtr || bcPtr->penalty() <= 0.)
+                continue;
+
+            variableManager.BindingConstraintPenaltyPos(bc, pdt) = -1;
+            variableManager.BindingConstraintPenaltyNeg(bc, pdt) = -1;
+
+            if (bcPtr->operatorType() == Antares::Data::BindingConstraint::opLess ||
+                bcPtr->operatorType() == Antares::Data::BindingConstraint::opBoth ||
+                bcPtr->operatorType() == Antares::Data::BindingConstraint::opEquality)
+            {
+                variableManager.BindingConstraintPenaltyPos(bc, pdt) = NombreDeVariables;
+                ProblemeAResoudre->TypeDeVariable[NombreDeVariables] = VARIABLE_BORNEE_INFERIEUREMENT;
+                variableNamer.BindingConstraintPenaltyPos(NombreDeVariables, bcPtr->name());
+                ++NombreDeVariables;
+            }
+
+            if (bcPtr->operatorType() == Antares::Data::BindingConstraint::opGreater ||
+                bcPtr->operatorType() == Antares::Data::BindingConstraint::opBoth ||
+                bcPtr->operatorType() == Antares::Data::BindingConstraint::opEquality)
+            {
+                variableManager.BindingConstraintPenaltyNeg(bc, pdt) = NombreDeVariables;
+                ProblemeAResoudre->TypeDeVariable[NombreDeVariables] = VARIABLE_BORNEE_INFERIEUREMENT;
+                variableNamer.BindingConstraintPenaltyNeg(NombreDeVariables, bcPtr->name());
+                ++NombreDeVariables;
+            }
+        }
         }
 
         for (uint32_t pays = 0; pays < problemeHebdo->NombreDePays; pays++)

--- a/src/solver/optimisation/opt_gestion_des_couts_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_des_couts_cas_lineaire.cpp
@@ -329,6 +329,24 @@ void OPT_InitialiserLesCoutsLineaire(PROBLEME_HEBDO* problemeHebdo,
                 ProblemeAResoudre->CoutLineaire[var] = problemeHebdo
                                                          ->CoutDeDefaillanceNegative[pays];
             }
+
+        for (uint32_t bc = 0; bc < problemeHebdo->NombreDeContraintesCouplantes; ++bc)
+        {
+            const auto* bcPtr = problemeHebdo->MatriceDesContraintesCouplantes[bc].bindingConstraint.get();
+            if (!bcPtr || bcPtr->penalty() <= 0.)
+                continue;
+
+            var = variableManager.BindingConstraintPenaltyPos(bc, pdtJour);
+            if (var >= 0 && var < ProblemeAResoudre->NombreDeVariables)
+            {
+                ProblemeAResoudre->CoutLineaire[var] = bcPtr->penalty();
+            }
+            var = variableManager.BindingConstraintPenaltyNeg(bc, pdtJour);
+            if (var >= 0 && var < ProblemeAResoudre->NombreDeVariables)
+            {
+                ProblemeAResoudre->CoutLineaire[var] = bcPtr->penalty();
+            }
+        }
         }
 
         pdtJour++;

--- a/src/solver/optimisation/opt_rename_problem.cpp
+++ b/src/solver/optimisation/opt_rename_problem.cpp
@@ -242,6 +242,16 @@ void VariableNamer::NegativeUnsuppliedEnergy(unsigned int variable)
     SetAreaElementNameHour(variable, "NegativeUnsuppliedEnergy");
 }
 
+void VariableNamer::BindingConstraintPenaltyPos(unsigned int variable, const std::string& name)
+{
+    SetAreaElementNameHour(variable, "BCPenaltyPos" + name);
+}
+
+void VariableNamer::BindingConstraintPenaltyNeg(unsigned int variable, const std::string& name)
+{
+    SetAreaElementNameHour(variable, "BCPenaltyNeg" + name);
+}
+
 void VariableNamer::AreaBalance(unsigned int variable)
 {
     SetAreaElementNameHour(variable, "AreaBalance");

--- a/src/solver/optimisation/variables/VariableManagement.cpp
+++ b/src/solver/optimisation/variables/VariableManagement.cpp
@@ -222,3 +222,21 @@ int& VariableManager::NegativeUnsuppliedEnergy(unsigned int index,
     auto pdt = GetShiftedTimeStep(offset, delta, hourInWeek);
     return CorrespondanceVarNativesVarOptim_[pdt].NumeroDeVariableDefaillanceNegative[index];
 }
+
+int& VariableManager::BindingConstraintPenaltyPos(unsigned int index,
+                                                  unsigned int hourInWeek,
+                                                  int offset,
+                                                  int delta)
+{
+    auto pdt = GetShiftedTimeStep(offset, delta, hourInWeek);
+    return CorrespondanceVarNativesVarOptim_[pdt].BindingConstraintPenaltyPos[index];
+}
+
+int& VariableManager::BindingConstraintPenaltyNeg(unsigned int index,
+                                                  unsigned int hourInWeek,
+                                                  int offset,
+                                                  int delta)
+{
+    auto pdt = GetShiftedTimeStep(offset, delta, hourInWeek);
+    return CorrespondanceVarNativesVarOptim_[pdt].BindingConstraintPenaltyNeg[index];
+}

--- a/src/solver/optimisation/variables/VariableManagement.h
+++ b/src/solver/optimisation/variables/VariableManagement.h
@@ -101,6 +101,16 @@ public:
                                   int offset = 0,
                                   int delta = 0);
 
+    int& BindingConstraintPenaltyPos(unsigned int index,
+                                     unsigned int hourInWeek,
+                                     int offset = 0,
+                                     int delta = 0);
+
+    int& BindingConstraintPenaltyNeg(unsigned int index,
+                                     unsigned int hourInWeek,
+                                     int offset = 0,
+                                     int delta = 0);
+
 private:
     std::vector<CORRESPONDANCES_DES_VARIABLES>& CorrespondanceVarNativesVarOptim_;
     std::vector<int>& NumeroDeVariableStockFinal_;

--- a/src/solver/simulation/include/antares/solver/simulation/sim_structure_probleme_economique.h
+++ b/src/solver/simulation/include/antares/solver/simulation/sim_structure_probleme_economique.h
@@ -73,6 +73,9 @@ struct CORRESPONDANCES_DES_VARIABLES
         std::vector<int> CostVariationInjection;
         std::vector<int> CostVariationWithdrawal;
     } SIM_ShortTermStorage;
+
+    std::vector<int> BindingConstraintPenaltyPos;
+    std::vector<int> BindingConstraintPenaltyNeg;
 };
 
 struct CORRESPONDANCES_DES_CONTRAINTES

--- a/src/solver/simulation/sim_alloc_probleme_hebdo.cpp
+++ b/src/solver/simulation/sim_alloc_probleme_hebdo.cpp
@@ -187,6 +187,8 @@ void SIM_AllocationProblemePasDeTemps(PROBLEME_HEBDO& problem,
                                                                             0);
         variablesMapping.SIM_ShortTermStorage.CostVariationWithdrawal.assign(shortTermStorageCount,
                                                                              0);
+        variablesMapping.BindingConstraintPenaltyPos.assign(activeConstraints.size(), 0);
+        variablesMapping.BindingConstraintPenaltyNeg.assign(activeConstraints.size(), 0);
 
         problem.CorrespondanceCntNativesCntOptim[k].NumeroDeContrainteDesBilansPays.assign(nbPays,
                                                                                            0);

--- a/src/tests/end-to-end/binding_constraints/CMakeLists.txt
+++ b/src/tests/end-to-end/binding_constraints/CMakeLists.txt
@@ -4,6 +4,7 @@ add_boost_test(tests-binding_constraints
      SRC
      test_binding_constraints.cpp
      test_binding_constraints_with_mustrun.cpp
+     test_binding_constraints_penalty.cpp
      LIBS
      model_antares
      antares-solver-simulation

--- a/src/tests/end-to-end/binding_constraints/test_binding_constraints_penalty.cpp
+++ b/src/tests/end-to-end/binding_constraints/test_binding_constraints_penalty.cpp
@@ -1,0 +1,29 @@
+#include <boost/test/unit_test.hpp>
+#include "in-memory-study.h"
+
+namespace utf = boost::unit_test;
+namespace tt = boost::test_tools;
+
+struct StudyWithPenalty: public StudyWithBConLink
+{
+    using StudyWithBConLink::StudyWithBConLink;
+};
+
+BOOST_AUTO_TEST_SUITE(TESTS_BINDING_CONSTRAINTS_PENALTY)
+
+BOOST_FIXTURE_TEST_CASE(hourly_BC_with_penalty_is_soft, StudyWithPenalty)
+{
+    setNumberMCyears(1);
+    BC->setTimeGranularity(BindingConstraint::typeHourly);
+    BC->operatorType(BindingConstraint::opEquality);
+    BC->penalty(100.);
+    TimeSeriesConfigurer(BC->RHSTimeSeries()).setDimensions(1).fillColumnWith(0, 0.);
+
+    simulation->create();
+    simulation->run();
+
+    OutputRetriever output(simulation->rawSimu());
+    BOOST_TEST(output.flow(link).hour(0) > 0.0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- allow defining a penalty cost for binding constraints
- save/load `penalty-cost` in INI files
- integrate penalties via slack variables in the optimisation
- document new setting
- add regression test for binding-constraint penalties

## Testing
- `cmake -S src -B build` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_685e76bf293c8330a4e28466b43099fe