### PR TITLE
Add weekly level option to short-term storage

### DIFF
--- a/docs/user-guide/04-migration-guides.md
+++ b/docs/user-guide/04-migration-guides.md
@@ -34,13 +34,16 @@ the simulation will fail with a warning. We recommend removing these properties 
       input/st-storage/clusters/<area id>/list.ini)
     - `penalize-variation-withdrawal` boolean, default false (file
       input/st-storage/clusters/<area id>/list.ini)
+    - `weekly-levels` boolean, default false (file
+      input/st-storage/clusters/<area id>/list.ini)
 
 - Added 5 optional timeseries for each STS in existing directory `input/st-storage/series/<area id>/<ST id>/`
 	- `cost-injection.txt`
 	- `cost-withdrawal.txt`
 	- `cost-level.txt`
-	- `cost-variation-injection.txt`
-	- `cost-variation-withdrawal.txt`
+        - `cost-variation-injection.txt`
+        - `cost-variation-withdrawal.txt`
+        - `weekly-levels.txt` one line per week with two columns: initial and final level (in % of capacity)
 
 It is possible to provide only k of these time-series, for k=0..5. However, if present each file must contain either no value (same behavior as no file), or HOURS_PER_YEAR = 8760 coefficients in one column. These timeseries are located along existing series (rule-curves.txt, etc.).
 

--- a/docs/user-guide/solver/02-inputs.md
+++ b/docs/user-guide/solver/02-inputs.md
@@ -347,8 +347,9 @@ The user may pick any area appearing in the area list and is then given access t
   - Efficiency (%): the energy efficiency of the storage, i.e. the ratio for a given volume between the energy taken from the system to be injected into the storage and the energy returned to the system during its withdrawal. This efficiency factor is applied when injecting energy into the storage.
   - Efficiency Withdrawal (%): Same behavior as the previous efficiency, this factor is applied when withdrawing energy from the storage.
   - Initial level (%): the imposed initial filling rate of the storage at the beginning of each optimisation period.
-  - Initial level optimal: if the parameter is activated, the "Initial level" parameter is ignored and the initial storage level is optimized by Antares for each optimization period to minimize its objective function.  
+  - Initial level optimal: if the parameter is activated, the "Initial level" parameter is ignored and the initial storage level is optimized by Antares for each optimization period to minimize its objective function.
     _Note: setting this parameter to "True" implies that there is no guarantee that the initial storage level of week N is the same as the final storage level of week N-1. However, the final level of week N is always equal to the initial level of the same week N plus/minus the injections/withdrawals occuring at the last hour of week N._
+  - Weekly levels: when set to `true`, the solver reads file `weekly-levels.txt` in each series folder to fix the storage level at the first and last hour of every week. The file contains 53 lines with two columns: the initial and final levels as fractions of the reservoir capacity.
 
 - "Injections/withdrawal capacities": a hourly time-series of modulation factors of the injection and withdrawal capacity for each hour (between 0 and 1), reflecting a lower availability of the structures during certain periods. At a given hour, the overall injection/withdrawal capacities of the storage are the product of this modulation factor by the "Withdrawal" and "Injection" parameters in the General data.
 

--- a/src/libs/antares/study/include/antares/study/parts/short-term-storage/cluster.h
+++ b/src/libs/antares/study/include/antares/study/parts/short-term-storage/cluster.h
@@ -54,5 +54,8 @@ public:
     std::shared_ptr<Series> series = std::make_shared<Series>();
     mutable Properties properties;
     std::vector<std::shared_ptr<AdditionalConstraints>> additionalConstraints;
+
+    std::vector<double> weeklyInitial;
+    std::vector<double> weeklyFinal;
 };
 } // namespace Antares::Data::ShortTermStorage

--- a/src/libs/antares/study/include/antares/study/parts/short-term-storage/properties.h
+++ b/src/libs/antares/study/include/antares/study/parts/short-term-storage/properties.h
@@ -60,6 +60,9 @@ public:
     bool penalizeVariationWithdrawal = false;
     bool penalizeVariationInjection = false;
 
+    /// If true, weekly-levels.txt will be read for each STS
+    bool weeklyLevels = false;
+
     /// Enabled ?
     bool enabled = true;
 

--- a/src/libs/antares/study/parts/short-term-storage/cluster.cpp
+++ b/src/libs/antares/study/parts/short-term-storage/cluster.cpp
@@ -22,8 +22,10 @@
 
 #include <yuni/core/string.h>
 #include <yuni/io/file.h>
+#include <fstream>
 
 #include <antares/logs/logs.h>
+#include "antares/antares/constants.h"
 #include <antares/utils/utils.h>
 
 namespace Antares::Data::ShortTermStorage
@@ -80,6 +82,36 @@ bool STStorageCluster::loadSeries(const std::filesystem::path& folder,
 {
     bool ret = series->loadFromFolder(folder, studyVersion);
     series->fillDefaultSeriesIfEmpty(); // fill series if no file series
+
+    if (properties.weeklyLevels)
+    {
+        fs::path weeklyPath = folder / "weekly-levels.txt";
+        std::ifstream file(weeklyPath);
+        if (file.is_open())
+        {
+            double init = 0.0, fin = 0.0;
+            weeklyInitial.clear();
+            weeklyFinal.clear();
+            while (file >> init >> fin)
+            {
+                weeklyInitial.push_back(init);
+                weeklyFinal.push_back(fin);
+            }
+            if (weeklyInitial.size() != WEEKS_PER_YEAR)
+            {
+                logs.warning() << "Short-term storage " << id
+                               << " invalid weekly-levels.txt size: "
+                               << weeklyInitial.size() << ", expected "
+                               << WEEKS_PER_YEAR;
+            }
+        }
+        else
+        {
+            logs.info() << "Optional file not found: " << weeklyPath
+                        << ", default values will be used if needed";
+        }
+    }
+
     return ret;
 }
 

--- a/src/libs/antares/study/parts/short-term-storage/properties.cpp
+++ b/src/libs/antares/study/parts/short-term-storage/properties.cpp
@@ -99,6 +99,11 @@ bool Properties::loadKey(const IniFile::Property* p)
         return p->value.to<bool>(this->penalizeVariationInjection);
     }
 
+    if (p->key == "weekly-levels")
+    {
+        return p->value.to<bool>(this->weeklyLevels);
+    }
+
     if (p->key == "enabled")
     {
         return p->value.to<bool>(this->enabled);
@@ -123,6 +128,7 @@ void Properties::save(IniFile& ini) const
     s->add("initialleveloptim", this->initialLevelOptim);
     s->add("penalize-variation-injection", this->penalizeVariationInjection);
     s->add("penalize-variation-withdrawal", this->penalizeVariationWithdrawal);
+    s->add("weekly-levels", this->weeklyLevels);
     s->add("enabled", this->enabled);
 }
 

--- a/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
@@ -178,10 +178,33 @@ static void setBoundsForShortTermStorage(PROBLEME_HEBDO* problemeHebdo,
 
                 // 3. Levels
                 int varLevel = variableManager.ShortTermStorageLevel(clusterGlobalIndex, pdtJour);
-                if (pdtHebdo == DernierPdtDeLIntervalle - 1 && !storage.initialLevelOptim)
+                if (storage.weeklyLevels)
                 {
-                    Xmin[varLevel] = Xmax[varLevel] = storage.reservoirCapacity
-                                                      * storage.initialLevel;
+                    if (pdtHebdo == 0 && storage.weeklyInitial.size() > problemeHebdo->weekInTheYear)
+                    {
+                        Xmin[varLevel] = Xmax[varLevel]
+                                         = storage.reservoirCapacity
+                                           * storage.weeklyInitial[problemeHebdo->weekInTheYear];
+                    }
+                    else if (pdtHebdo == DernierPdtDeLIntervalle - 1
+                             && storage.weeklyFinal.size() > problemeHebdo->weekInTheYear)
+                    {
+                        Xmin[varLevel] = Xmax[varLevel]
+                                         = storage.reservoirCapacity
+                                           * storage.weeklyFinal[problemeHebdo->weekInTheYear];
+                    }
+                    else
+                    {
+                        Xmin[varLevel] = storage.reservoirCapacity
+                                         * storage.series->lowerRuleCurve[hourInTheYear];
+                        Xmax[varLevel] = storage.reservoirCapacity
+                                         * storage.series->upperRuleCurve[hourInTheYear];
+                    }
+                }
+                else if (pdtHebdo == DernierPdtDeLIntervalle - 1 && !storage.initialLevelOptim)
+                {
+                    Xmin[varLevel] = Xmax[varLevel]
+                                      = storage.reservoirCapacity * storage.initialLevel;
                 }
                 else
                 {

--- a/src/solver/simulation/include/antares/solver/simulation/sim_structure_probleme_economique.h
+++ b/src/solver/simulation/include/antares/solver/simulation/sim_structure_probleme_economique.h
@@ -182,6 +182,10 @@ struct PROPERTIES
     bool penalizeVariationWithdrawal;
     bool penalizeVariationInjection;
 
+    bool weeklyLevels;
+    std::vector<double> weeklyInitial;
+    std::vector<double> weeklyFinal;
+
     std::shared_ptr<Antares::Data::ShortTermStorage::Series> series;
     std::vector<std::shared_ptr<Antares::Data::ShortTermStorage::AdditionalConstraints>>
       additionalConstraints;

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -62,7 +62,13 @@ static void importShortTermStorages(
             toInsert.initialLevelOptim = st.properties.initialLevelOptim;
             toInsert.penalizeVariationInjection = st.properties.penalizeVariationInjection;
             toInsert.penalizeVariationWithdrawal = st.properties.penalizeVariationWithdrawal;
+            toInsert.weeklyLevels = st.properties.weeklyLevels;
             toInsert.name = st.properties.name;
+            if (st.properties.weeklyLevels)
+            {
+                toInsert.weeklyInitial = st.weeklyInitial;
+                toInsert.weeklyFinal = st.weeklyFinal;
+            }
             for (const auto& constraint: st.additionalConstraints)
             {
                 if (constraint->enabled)


### PR DESCRIPTION
## Summary
- add `weekly-levels` flag to short‑term storage properties
- load new `weekly-levels.txt` series when the option is enabled
- expose weekly levels in solver structures and import
- fix level bounds in optimisation when weekly levels are set
- document the new option and file in user guide

## Testing
- `ctest -N`

------
https://chatgpt.com/codex/tasks/task_e_6860781a6b8c83308c28e663b4955253